### PR TITLE
fix(docker): update Node.js base image to v22

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # --- Etapa 1: Construir la App ---
-FROM node:18-alpine as build
+FROM node:22-alpine as build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
Upgrades the build stage base image from node:18-alpine to node:22-alpine to meet the minimum requirements of the Angular CLI (requires v20.19+ or v22.12+). Also fixes Dockerfile syntax warning for 'AS' keyword casing.

Refs #19