### PR TITLE
fix(nginx): add mime types and cors headers for tunnel compatibility

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,15 +1,22 @@
 server {
     listen 80;
     server_name localhost;
+
     root /usr/share/nginx/html;
     index index.html;
-    
-    # Compresión para que cargue rápido
-    gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Soporte para los tipos de archivos (MIME types)
+    include /etc/nginx/mime.types;
 
     location / {
-        # Si no encuentra el archivo, sirve el index.html (Vital para Angular)
+        # Esto redirige todo al index.html para que Angular maneje las rutas
         try_files $uri $uri/ /index.html;
+    }
+
+    # Configuración específica para los assets (JS, CSS, Imágenes)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+        add_header Access-Control-Allow-Origin "*";
+        add_header Cache-Control "public, max-age=31536000";
+        try_files $uri =404;
     }
 }


### PR DESCRIPTION
The previous Nginx configuration lacked explicit MIME type handling, causing Cloudflare Tunnel to misinterpret asset types (.js, .css) and return 404 errors. This update ensures that the browser correctly identifies and loads the Angular components.

Refs #26