### PR TITLE
fix(hero): center skill stats on mobile

### DIFF
--- a/src/app/features/landing/hero/skill-chart/skill-chart.component.css
+++ b/src/app/features/landing/hero/skill-chart/skill-chart.component.css
@@ -29,6 +29,10 @@
   @apply flex items-center gap-5;
 }
 
+.skill-chart__list {
+  @apply space-y-1;
+}
+
 .skill-chart__label {
   font-family: var(--font-display);
   @apply text-sm w-10;
@@ -61,6 +65,25 @@
 
 @media (max-width: 768px) {
   .skill-chart {
-    @apply w-48;
+    width: min(100%, 16rem);
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    box-sizing: border-box;
+    text-align: center;
+    transform: rotate(-1deg);
+    align-self: center;
+  }
+
+  .skill-chart__row {
+    @apply justify-center;
+  }
+
+  .skill-chart__title {
+    @apply text-base;
+  }
+
+  .skill-chart__label {
+    @apply text-sm;
   }
 }

--- a/src/app/features/landing/hero/skill-chart/skill-chart.component.html
+++ b/src/app/features/landing/hero/skill-chart/skill-chart.component.html
@@ -1,6 +1,6 @@
 <div class="skill-chart">
   <h4 class="skill-chart__title">SKILL STATS</h4>
-  <div class="space-y-1">
+  <div class="skill-chart__list">
     @for (skill of skills(); track skill.label) {
       <div class="skill-chart__row">
         <span class="skill-chart__label">{{ skill.label }}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -373,7 +373,7 @@
     }
 
     .hero__detail-row {
-      @apply flex-col gap-8;
+      @apply flex-col gap-8 items-center;
     }
 
     .hero__cta {


### PR DESCRIPTION
Center the Skill Stats card in the hero layout for small screens. Align the stacked layout so the card no longer drifts left.

Resolves #35