### PR TITLE
assets(favicon): update favicon and page title

### DIFF
--- a/src/assets/favicon.svg
+++ b/src/assets/favicon.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg version="1.1" id="Uploaded to svgrepo.com" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 width="800px" height="800px" viewBox="0 0 32 32" xml:space="preserve">
+<style type="text/css">
+	.cubies_veertien{fill:#BCD269;}
+	.cubies_vijftien{fill:#D1DE8B;}
+	.cubies_achtien{fill:#EDB57E;}
+	.cubies_zesentwintig{fill:#65C3AB;}
+	.cubies_zevenentwintig{fill:#98D3BC;}
+	.cubies_twee{fill:#67625D;}
+	.cubies_een{fill:#4C4842;}
+	.cubies_negentien{fill:#F2C99E;}
+	.cubies_tweeentwintig{fill:#D97360;}
+	.cubies_drieentwintig{fill:#E69D8A;}
+	.cubies_drie{fill:#837F79;}
+	.cubies_vier{fill:#A5A29C;}
+	.st0{fill:#A4C83F;}
+	.st1{fill:#2EB39A;}
+	.st2{fill:#EC9B5A;}
+	.st3{fill:#A5C64A;}
+	.st4{fill:#F9E0BD;}
+	.st5{fill:#CCE2CD;}
+	.st6{fill:#C9483A;}
+	.st7{fill:#FFF2DF;}
+	.st8{fill:#C9C6C0;}
+	.st9{fill:#725A48;}
+	.st10{fill:#8E7866;}
+	.st11{fill:#EDEAE5;}
+	.st12{fill:#E3D4C0;}
+	.st13{fill:#E8E8B5;}
+	.st14{fill:#F2C99E;}
+	.st15{fill:#EDB57E;}
+	.st16{fill:#AB9784;}
+</style>
+<g>
+	<path class="cubies_een" d="M29,32H3c-1.657,0-3-1.343-3-3V3c0-1.657,1.343-3,3-3h26c1.657,0,3,1.343,3,3v26
+		C32,30.657,30.657,32,29,32z"/>
+	<path class="cubies_twee" d="M27,32H3c-1.657,0-3-1.343-3-3V3c0-1.657,1.343-3,3-3h24c1.657,0,3,1.343,3,3v26
+		C30,30.657,28.657,32,27,32z"/>
+	<path class="cubies_drie" d="M12,14h-2v-2c0-0.552-0.448-1-1-1H6c-0.552,0-1,0.448-1,1v2H3c-0.552,0-1,0.448-1,1v2
+		c0,0.552,0.448,1,1,1h2v2c0,0.552,0.448,1,1,1h3c0.552,0,1-0.448,1-1v-2h2c0.552,0,1-0.448,1-1v-2C13,14.448,12.552,14,12,14z"/>
+	<path class="cubies_vier" d="M11,14H9v-2c0-0.552-0.448-1-1-1H6c-0.552,0-1,0.448-1,1v2H3c-0.552,0-1,0.448-1,1v2
+		c0,0.552,0.448,1,1,1h2v2c0,0.552,0.448,1,1,1h2c0.552,0,1-0.448,1-1v-2h2c0.552,0,1-0.448,1-1v-2C12,14.448,11.552,14,11,14z"/>
+	<path class="cubies_achtien" d="M20,11c-0.174,0-0.826,0-1,0c-1.105,0-2,0.895-2,2c0,1.105,0.895,2,2,2c0.174,0,0.826,0,1,0
+		c1.105,0,2-0.895,2-2C22,11.895,21.105,11,20,11z"/>
+	<circle class="cubies_negentien" cx="19" cy="13" r="2"/>
+	<path class="cubies_zesentwintig" d="M26,11c-0.174,0-0.826,0-1,0c-1.105,0-2,0.895-2,2c0,1.105,0.895,2,2,2c0.174,0,0.826,0,1,0
+		c1.105,0,2-0.895,2-2C28,11.895,27.105,11,26,11z"/>
+	<circle class="cubies_zevenentwintig" cx="25" cy="13" r="2"/>
+	<path class="cubies_tweeentwintig" d="M26,17c-0.174,0-0.826,0-1,0c-1.105,0-2,0.895-2,2c0,1.105,0.895,2,2,2c0.174,0,0.826,0,1,0
+		c1.105,0,2-0.895,2-2C28,17.895,27.105,17,26,17z"/>
+	<path class="cubies_veertien" d="M20,17c-0.174,0-0.826,0-1,0c-1.105,0-2,0.895-2,2c0,1.105,0.895,2,2,2c0.174,0,0.826,0,1,0
+		c1.105,0,2-0.895,2-2C22,17.895,21.105,17,20,17z"/>
+	<circle class="cubies_drieentwintig" cx="25" cy="19" r="2"/>
+	<circle class="cubies_vijftien" cx="19" cy="19" r="2"/>
+</g>
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,10 @@
 <html lang="en" class="scroll-smooth dark">
 <head>
   <meta charset="utf-8">
-  <title>Portfolio</title>
+  <title>Koji's Portfolio</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Replace the default favicon with the brand icon and update the document title. This aligns the tab branding with the portfolio identity.

Resolves #33