### PR TITLE
feat(loading): add sketch loader for CMS fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^21.1.4",
         "@angular/common": "^21.1.0",
         "@angular/compiler": "^21.1.0",
         "@angular/core": "^21.1.0",
@@ -336,6 +337,21 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "21.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.1.4.tgz",
+      "integrity": "sha512-8xQ0Ylw7qqVyw4ZJ/Tyw/z5Mtqtp8AMj+R+Z1sCWcyxBgDU4+qfxteVYdiipWC3tX77A0FTsXqwvNP9WVY2/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "21.1.4"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "private": true,
   "packageManager": "npm@11.6.2",
   "dependencies": {
+    "@angular/animations": "^21.1.4",
     "@angular/common": "^21.1.0",
     "@angular/compiler": "^21.1.0",
     "@angular/core": "^21.1.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,10 @@
 import { APP_INITIALIZER, ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { AppConfigService } from './core/services/app-config.service';
-import { PortfolioContentService } from './core/services/portfolio-content.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -13,10 +13,11 @@ export const appConfig: ApplicationConfig = {
     {
       provide: APP_INITIALIZER,
       multi: true,
-      deps: [AppConfigService, PortfolioContentService],
-      useFactory: (appConfigService: AppConfigService, portfolioContent: PortfolioContentService) => () =>
-        appConfigService.load().then(() => portfolioContent.load(3000))
+      deps: [AppConfigService],
+      useFactory: (appConfigService: AppConfigService) => () =>
+        appConfigService.load()
     },
+    provideAnimations(),
     provideRouter(routes)
   ]
 };

--- a/src/app/core/layout/shell/shell.component.html
+++ b/src/app/core/layout/shell/shell.component.html
@@ -1,7 +1,12 @@
 <!-- Global shell keeps navigation persistent across routes. -->
-<app-top-nav />
+@if (isLoading()) {
+  <app-loading-sketch @fadeOverlay />
+}
 
-<main class="pt-20">
-  <!-- Feature routes render here. -->
-  <router-outlet />
-</main>
+@if (!isLoading()) {
+  <app-top-nav />
+  <main class="pt-20" @fadeContent>
+    <!-- Feature routes render here. -->
+    <router-outlet />
+  </main>
+}

--- a/src/app/core/layout/shell/shell.component.ts
+++ b/src/app/core/layout/shell/shell.component.ts
@@ -1,13 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, effect, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+import { animate, style, transition, trigger } from '@angular/animations';
 
+import { PortfolioContentService } from '../../services/portfolio-content.service';
+import { LoadingSketchComponent } from '../../../shared/loading-sketch/loading-sketch.component';
 import { TopNavComponent } from '../top-nav/top-nav.component';
 
 @Component({
   selector: 'app-shell',
   standalone: true,
-  imports: [RouterOutlet, TopNavComponent],
+  imports: [RouterOutlet, TopNavComponent, LoadingSketchComponent],
   templateUrl: './shell.component.html',
-  styleUrl: './shell.component.css'
+  styleUrl: './shell.component.css',
+  animations: [
+    trigger('fadeOverlay', [
+      transition(':enter', [style({ opacity: 0 }), animate('300ms ease-out', style({ opacity: 1 }))]),
+      transition(':leave', [animate('250ms ease-in', style({ opacity: 0 }))])
+    ]),
+    trigger('fadeContent', [
+      transition(':enter', [style({ opacity: 0 }), animate('350ms ease-out', style({ opacity: 1 }))])
+    ])
+  ]
 })
-export class ShellComponent {}
+export class ShellComponent implements OnInit {
+  private readonly portfolioContent = inject(PortfolioContentService);
+  private readonly document = inject(DOCUMENT);
+
+  protected readonly isLoading = this.portfolioContent.loading;
+
+  constructor() {
+    effect(() => {
+      this.document.body.style.overflow = this.isLoading() ? 'hidden' : '';
+    });
+  }
+
+  ngOnInit(): void {
+    void this.portfolioContent.load(300);
+  }
+}

--- a/src/app/shared/loading-sketch/loading-sketch.component.css
+++ b/src/app/shared/loading-sketch/loading-sketch.component.css
@@ -1,0 +1,50 @@
+@reference "../../../styles.css";
+
+:host {
+  @apply fixed inset-0 z-[9999] flex items-center justify-center bg-background-light/95 dark:bg-background-dark/95;
+  backdrop-filter: blur(6px);
+}
+
+.loading-sketch {
+  @apply flex items-center justify-center;
+}
+
+.loading-sketch__content {
+  @apply flex flex-col items-center gap-4;
+}
+
+.loading-sketch__spinner {
+  width: 72px;
+  height: 72px;
+  border-radius: 9999px;
+  border: 4px dashed #000000;
+  animation: sketch-spin 1.2s linear infinite;
+  box-shadow: 6px 6px 0 0 rgba(0, 0, 0, 1);
+}
+
+.loading-sketch__text {
+  font-family: var(--font-display);
+  @apply text-2xl uppercase text-black dark:text-white;
+  animation: flicker 1.4s steps(2) infinite;
+}
+
+@keyframes sketch-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes flicker {
+  0% {
+    opacity: 0.9;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/app/shared/loading-sketch/loading-sketch.component.html
+++ b/src/app/shared/loading-sketch/loading-sketch.component.html
@@ -1,0 +1,6 @@
+<div class="loading-sketch">
+  <div class="loading-sketch__content">
+    <div class="loading-sketch__spinner"></div>
+    <p class="loading-sketch__text">{{ phrase() }}</p>
+  </div>
+</div>

--- a/src/app/shared/loading-sketch/loading-sketch.component.ts
+++ b/src/app/shared/loading-sketch/loading-sketch.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-loading-sketch',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './loading-sketch.component.html',
+  styleUrl: './loading-sketch.component.css',
+  standalone: true
+})
+export class LoadingSketchComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly phrases = [
+    'Bocetando...',
+    'Entintando...',
+    'Trazando lineas...',
+    'Cargando ideas...',
+    'Ajustando el lápiz...',
+    'Preparando escena...',
+    'Ajustando la brújula...',
+  ];
+
+  private readonly phraseIndex = signal(0);
+
+  protected readonly phrase = computed(() =>
+    this.phrases[this.phraseIndex()]
+  );
+
+  constructor() {
+    const intervalId = setInterval(() => {
+      const nextIndex = Math.floor(Math.random() * this.phrases.length);
+      this.phraseIndex.set(nextIndex);
+    }, 1100);
+
+    this.destroyRef.onDestroy(() => clearInterval(intervalId));
+  }
+}


### PR DESCRIPTION
Introduce a full‑screen sketch loader with Spanish phrases during the initial CMS fetch. Add a smooth fade transition and remove the hard pause to depend on real load time.

Resolves #45