### PR TITLE
fix(theme): persist light mode across project detail view

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,7 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+
+import { ThemeService } from './core/services/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -7,6 +9,11 @@ import { RouterOutlet } from '@angular/router';
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
-export class App {
+export class App implements OnInit {
+  private readonly theme = inject(ThemeService);
   protected readonly title = signal('Portfolio');
+
+  ngOnInit(): void {
+    this.theme.init();
+  }
 }

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -6,9 +6,49 @@ import { Injectable, inject } from '@angular/core';
 })
 export class ThemeService {
   private readonly document = inject(DOCUMENT);
+  private readonly storageKey = 'theme';
+
+  init(): void {
+    const stored = this.readStoredTheme();
+    if (stored) {
+      this.applyTheme(stored === 'dark');
+      return;
+    }
+
+    const prefersDark = this.document.defaultView?.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
+    this.applyTheme(prefersDark);
+  }
 
   // Matches the template behavior: toggles the "dark" class on <html>.
   toggle(): void {
-    this.document.documentElement.classList.toggle('dark');
+    const isDark = !this.document.documentElement.classList.contains('dark');
+    this.applyTheme(isDark);
+  }
+
+  private applyTheme(isDark: boolean): void {
+    this.document.documentElement.classList.toggle('dark', isDark);
+    this.document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+    this.storeTheme(isDark ? 'dark' : 'light');
+  }
+
+  private readStoredTheme(): 'dark' | 'light' | null {
+    try {
+      const stored = this.document.defaultView?.localStorage?.getItem(this.storageKey);
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  }
+
+  private storeTheme(value: 'dark' | 'light'): void {
+    try {
+      this.document.defaultView?.localStorage?.setItem(this.storageKey, value);
+    } catch {
+      return;
+    }
   }
 }

--- a/src/app/features/project-detail/cta/project-detail-cta.component.css
+++ b/src/app/features/project-detail/cta/project-detail-cta.component.css
@@ -2,8 +2,7 @@
 @reference "../../../shared/styles/project-detail.shared.css";
 
 .project-cta {
-  @apply relative py-24 flex items-center justify-center overflow-hidden;
-  background-color: #1a1a1a;
+  @apply relative py-24 flex items-center justify-center overflow-hidden bg-background-light dark:bg-darkblue;
 }
 
 .project-cta__noise {
@@ -86,10 +85,18 @@
 
 @media (max-width: 768px) {
   .project-cta__primary {
-    @apply text-2xl px-8 py-4;
+    @apply text-xl px-5 py-3 w-full;
+    min-width: 0;
+    min-height: 0;
+    max-width: 320px;
+    white-space: nowrap;
   }
 
   .project-cta__secondary {
-    @apply text-xl px-8 py-4;
+    @apply text-lg px-5 py-3 w-full;
+    min-width: 0;
+    min-height: 0;
+    max-width: 320px;
+    white-space: nowrap;
   }
 }

--- a/src/app/features/project-detail/footage/project-detail-footage.component.css
+++ b/src/app/features/project-detail/footage/project-detail-footage.component.css
@@ -2,8 +2,7 @@
 @reference "../../../shared/styles/project-detail.shared.css";
 
 .project-footage {
-  @apply relative py-24;
-  background-color: #111111;
+  @apply relative py-24 bg-background-light dark:bg-black;
 }
 
 .project-footage__noise {

--- a/src/app/features/project-detail/hero/project-detail-hero.component.css
+++ b/src/app/features/project-detail/hero/project-detail-hero.component.css
@@ -2,8 +2,7 @@
 @reference "../../../shared/styles/project-detail.shared.css";
 
 .project-hero {
-  @apply relative min-h-screen flex flex-col items-center justify-center pt-24 pb-12 overflow-hidden;
-  background-color: #1a1a1a;
+  @apply relative min-h-screen flex flex-col items-center justify-center pt-24 pb-12 overflow-hidden bg-background-light dark:bg-darkblue;
 }
 
 .project-hero__noise {
@@ -34,7 +33,7 @@
 
 .project-hero__title {
   font-family: var(--font-display);
-  @apply text-5xl md:text-6xl lg:text-7xl text-white uppercase leading-none;
+  @apply text-5xl md:text-6xl lg:text-7xl text-black dark:text-white uppercase leading-none;
   transform: rotate(-2deg);
   letter-spacing: -0.06em;
   mix-blend-mode: screen;
@@ -45,7 +44,7 @@
 
 .project-hero__subtitle {
   font-family: var(--font-display);
-  @apply absolute -bottom-5 bg-black px-4 py-1 text-2xl;
+  @apply absolute -bottom-5 bg-white dark:bg-black px-4 py-1 text-2xl;
   display: inline-block;
   color: var(--color-secondary);
   border: 1px solid var(--color-secondary);
@@ -96,12 +95,12 @@
 }
 
 .project-hero__screen {
-  @apply bg-gray-800 rounded-t-xl p-2 pb-0 border-4 border-gray-700 shadow-2xl mx-auto w-full md:w-[80%] aspect-video relative overflow-hidden;
+  @apply bg-gray-200 dark:bg-gray-800 rounded-t-xl p-2 pb-0 border-4 border-gray-300 dark:border-gray-700 shadow-2xl mx-auto w-full md:w-[80%] aspect-video relative overflow-hidden;
 }
 
 .project-hero__screen-inner {
-  @apply w-full h-full rounded-t-lg overflow-hidden border border-gray-900 relative;
-  background-color: #0a0a0a;
+  @apply w-full h-full rounded-t-lg overflow-hidden border border-gray-300 dark:border-gray-900 relative;
+  background-color: #f5f5f5;
   padding-top: 32px;
 }
 
@@ -143,8 +142,12 @@
 }
 
 .project-hero__base {
-  @apply bg-gray-700 h-4 w-[90%] mx-auto rounded-b-xl border-t border-gray-600;
+  @apply bg-gray-200 dark:bg-gray-700 h-4 w-[90%] mx-auto rounded-b-xl border-t border-gray-300 dark:border-gray-600;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.8);
+}
+
+.dark .project-hero__screen-inner {
+  background-color: #0a0a0a;
 }
 
 @keyframes project-hero-scanline {

--- a/src/app/features/project-detail/scope/project-detail-scope.component.css
+++ b/src/app/features/project-detail/scope/project-detail-scope.component.css
@@ -2,8 +2,7 @@
 @reference "../../../shared/styles/project-detail.shared.css";
 
 .project-scope {
-  @apply relative py-20 border-t-2;
-  background-color: #1a1a1a;
+  @apply relative py-20 border-t-2 bg-background-light dark:bg-darkblue;
   border-color: var(--color-primary);
 }
 
@@ -118,7 +117,7 @@
 .project-architecture__frame {
   @apply relative p-6 border;
   border-color: rgba(0, 255, 255, 0.3);
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(255, 255, 255, 0.7);
   backdrop-filter: blur(6px);
   min-height: 600px;
 }
@@ -177,6 +176,10 @@
   height: 380px;
   overflow: hidden;
   background-color: transparent;
+}
+
+.dark .project-architecture__frame {
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .project-architecture__image {

--- a/src/app/features/project-detail/tech/project-detail-tech.component.css
+++ b/src/app/features/project-detail/tech/project-detail-tech.component.css
@@ -2,11 +2,10 @@
 @reference "../../../shared/styles/project-detail.shared.css";
 
 .project-tech {
-  @apply relative py-24 overflow-hidden;
-  background-color: #0a0a0a;
-  border-top: 4px solid #1a1a1a;
-  border-bottom: 4px solid #1a1a1a;
-  box-shadow: inset 0 0 150px rgba(0, 0, 0, 1);
+  @apply relative py-24 overflow-hidden bg-white dark:bg-black;
+  border-top: 4px solid #e5e7eb;
+  border-bottom: 4px solid #e5e7eb;
+  box-shadow: inset 0 0 90px rgba(0, 0, 0, 0.08);
 }
 
 .project-tech__noise {
@@ -16,7 +15,7 @@
 
 .project-tech__mark {
   font-family: var(--font-display);
-  @apply absolute -right-20 top-20 text-9xl text-white opacity-5 rotate-90 pointer-events-none;
+  @apply absolute -right-20 top-20 text-9xl text-black dark:text-white opacity-5 rotate-90 pointer-events-none;
 }
 
 .project-tech__container {
@@ -25,8 +24,8 @@
 
 .project-tech__title {
   font-family: var(--font-display);
-  @apply text-5xl md:text-7xl text-white text-center mb-16 uppercase;
-  -webkit-text-stroke: 1px rgba(255, 255, 255, 0.2);
+  @apply text-5xl md:text-7xl text-black dark:text-white text-center mb-16 uppercase;
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.15);
 }
 
 .project-tech__grid {
@@ -40,6 +39,16 @@
   color: var(--tech-text, #ffffff);
   box-shadow: 8px 8px 0 0 var(--tech-shadow, rgba(0, 0, 0, 0.4));
   transform: translate(var(--tech-shift-x, 0), var(--tech-shift-y, 0)) rotate(var(--tech-rotate, 0deg));
+}
+
+.dark .project-tech {
+  border-top: 4px solid #1a1a1a;
+  border-bottom: 4px solid #1a1a1a;
+  box-shadow: inset 0 0 150px rgba(0, 0, 0, 1);
+}
+
+.dark .project-tech__title {
+  -webkit-text-stroke: 1px rgba(255, 255, 255, 0.2);
 }
 
 .project-tech__card:hover {

--- a/src/app/shared/styles/project-detail.shared.css
+++ b/src/app/shared/styles/project-detail.shared.css
@@ -1,5 +1,5 @@
 @reference "../../../styles.css";
 
 .project-detail {
-  @apply bg-darkblue text-gray-100 overflow-x-hidden min-h-screen;
+  @apply bg-background-light text-gray-900 overflow-x-hidden min-h-screen dark:bg-darkblue dark:text-gray-100;
 }


### PR DESCRIPTION
Apply saved theme on init, set data-theme on <html>, and make the Project Detail sections theme-aware so light mode is honored after navigation. Adjust mobile CTA sizing to avoid overflow while keeping single-line labels.

Resolves #51