### PR TITLE
fix(theme): default to dark on first visit

### DIFF
--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -14,9 +14,7 @@ export class ThemeService {
       this.applyTheme(stored === 'dark');
       return;
     }
-
-    const prefersDark = this.document.defaultView?.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
-    this.applyTheme(prefersDark);
+    this.applyTheme(true);
   }
 
   // Matches the template behavior: toggles the "dark" class on <html>.


### PR DESCRIPTION
Force dark mode when no theme is stored, while preserving user toggles.

Resolves #53