### PR TITLE
feat(seo): add SeoService, runtime meta updates, default OG & favicons

### DIFF
--- a/src/app/core/services/seo.service.ts
+++ b/src/app/core/services/seo.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+
+@Injectable({ providedIn: 'root' })
+export class SeoService {
+  constructor(private title: Title, private meta: Meta) {}
+
+  setTitle(titleText: string) {
+    this.title.setTitle(titleText);
+  }
+
+  setDescription(description: string) {
+    if (!description) return;
+    this.meta.updateTag({ name: 'description', content: description });
+  }
+
+  setOpenGraph(options: { title?: string; description?: string; image?: string; url?: string }) {
+    const { title, description, image, url } = options;
+    if (title) {
+      this.meta.updateTag({ property: 'og:title', content: title });
+      this.meta.updateTag({ name: 'twitter:title', content: title });
+    }
+    if (description) {
+      this.meta.updateTag({ property: 'og:description', content: description });
+      this.meta.updateTag({ name: 'twitter:description', content: description });
+    }
+    if (image) {
+      this.meta.updateTag({ property: 'og:image', content: image });
+      this.meta.updateTag({ name: 'twitter:image', content: image });
+      this.meta.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
+    }
+    if (url) {
+      this.meta.updateTag({ property: 'og:url', content: url });
+    }
+  }
+
+  setCanonical(url: string) {
+    if (!url) return;
+    let link: HTMLLinkElement | null = document.querySelector("link[rel='canonical']");
+    if (!link) {
+      link = document.createElement('link');
+      link.setAttribute('rel', 'canonical');
+      document.head.appendChild(link);
+    }
+    link.setAttribute('href', url);
+  }
+}

--- a/src/app/features/landing/landing.page.ts
+++ b/src/app/features/landing/landing.page.ts
@@ -1,4 +1,6 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+
+import { SeoService } from '../../core/services/seo.service';
 
 import { AboutSectionComponent } from './about/about-section.component';
 import { ContactSectionComponent } from './contact/contact-section.component';
@@ -12,4 +14,18 @@ import { ProjectGalleryComponent } from './projects/project-gallery.component';
   templateUrl: './landing.page.html',
   styleUrl: './landing.page.css'
 })
-export class LandingPage {}
+export class LandingPage implements OnInit {
+  private readonly seo = inject(SeoService);
+
+  ngOnInit(): void {
+    const title = 'Portfolio | Kevin Sánchez';
+    const description = 'A visual, terminal-inspired portfolio showcasing experiments, projects, and process.';
+    const url = location.origin;
+    const image = `${location.origin}/assets/projects/detail/self-03.png`;
+
+    this.seo.setTitle(title);
+    this.seo.setDescription(description);
+    this.seo.setOpenGraph({ title, description, image, url });
+    this.seo.setCanonical(url);
+  }
+}

--- a/src/app/features/project-detail/project-detail.page.ts
+++ b/src/app/features/project-detail/project-detail.page.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { ProjectCard } from '../../core/models/portfolio-content.model';
 import { PortfolioContentService } from '../../core/services/portfolio-content.service';
+import { SeoService } from '../../core/services/seo.service';
 import { ProjectDetailNavComponent } from './nav/project-detail-nav.component';
 import { ProjectDetailHeroComponent } from './hero/project-detail-hero.component';
 import { ProjectDetailScopeComponent } from './scope/project-detail-scope.component';
@@ -30,6 +31,7 @@ export class ProjectDetailPage implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly portfolioContent = inject(PortfolioContentService);
+  private readonly seo = inject(SeoService);
 
   private readonly slug = signal('');
 
@@ -46,11 +48,49 @@ export class ProjectDetailPage implements OnInit {
         void this.router.navigate(['/'], { fragment: 'proyectos' });
       }
     });
+
+    effect(() => {
+      const project = this.project();
+      if (!project || this.portfolioContent.loading()) {
+        return;
+      }
+
+      const title = `${project.title} | Kevin Sánchez`;
+      const description = project.longDescription || project.description;
+      const image = this.resolveProjectImage(project);
+      const url = `${location.origin}/projects/${project.slug ?? ''}`;
+
+      this.seo.setTitle(title);
+      this.seo.setDescription(description);
+      this.seo.setOpenGraph({ title, description, image, url });
+      this.seo.setCanonical(url);
+    });
   }
 
   ngOnInit(): void {
     this.route.paramMap.subscribe(params => {
       this.slug.set(params.get('slug') ?? '');
     });
+  }
+
+  private resolveProjectImage(project: ProjectCard): string {
+    const fallback = `${location.origin}/assets/projects/detail/self-03.png`;
+    if (project.heroImage) {
+      return this.normalizeAssetUrl(project.heroImage, fallback);
+    }
+    if (project.image) {
+      return this.normalizeAssetUrl(project.image, fallback);
+    }
+    if (project.gallery?.length && project.gallery[0].src) {
+      return this.normalizeAssetUrl(project.gallery[0].src, fallback);
+    }
+    return fallback;
+  }
+
+  private normalizeAssetUrl(value: string, fallback: string): string {
+    if (!value) return fallback;
+    if (value.startsWith('http://') || value.startsWith('https://')) return value;
+    if (value.startsWith('/')) return `${location.origin}${value}`;
+    return `${location.origin}/${value}`;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,26 @@
 <html lang="en" class="scroll-smooth dark">
 <head>
   <meta charset="utf-8">
-  <title>Koji's Portfolio</title>
+  <title>Portfolio | Kevin Sánchez</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="Kevin Sánchez">
+  <meta name="description" content="Portfolio — a visual, terminal-inspired portfolio showcasing experiments, projects, and process.">
+  <meta name="keywords" content="portfolio, sketch, terminal, ui, frontend, angular, design">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Portfolio | Kevin Sánchez">
+  <meta property="og:description" content="A visual, terminal-inspired portfolio showcasing experiments, projects, and process.">
+  <meta property="og:image" content="/assets/projects/detail/self-03.png">
+  <meta property="og:url" content="/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Portfolio | Kevin Sánchez">
+  <meta name="twitter:description" content="A visual, terminal-inspired portfolio showcasing experiments, projects, and process.">
+  <meta name="twitter:image" content="/assets/projects/detail/self-03.png">
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon.svg">
+  <meta name="theme-color" content="#0b0b0b">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
- Add a reusable SeoService to centralize Title, description, OpenGraph and canonical updates.
- Wire runtime meta updates into LandingPage and ProjectDetail so titles and OG tags reflect current content (og:url built from location.origin).
- Resolve project OG image with fallback to /assets/projects/detail/self-03.png.
- Add static author/description/keywords and OG/Twitter defaults to src/index.html and include basic favicon/apple-touch links.
- Note crawler limitation: client-side meta improves browser UX but social crawlers may require prerender/snapshot for reliable per-project previews.

Resolves #58