### PR TITLE
feat(contact-form): add validation messages and disabled state

### DIFF
--- a/src/app/features/landing/contact/contact-form/contact-form.component.css
+++ b/src/app/features/landing/contact/contact-form/contact-form.component.css
@@ -48,6 +48,14 @@
   @apply resize-none;
 }
 
+.contact-form__error {
+  font-family: var(--font-display);
+  @apply text-sm uppercase;
+  color: #ff5a3d;
+  text-shadow: 0 0 8px rgba(255, 90, 61, 0.6);
+  letter-spacing: 0.04em;
+}
+
 .contact-form__actions {
   @apply text-center;
 }
@@ -63,9 +71,12 @@
 }
 
 .contact-form__submit:disabled {
-  @apply opacity-70 cursor-not-allowed;
+  @apply opacity-60 cursor-not-allowed;
+  filter: grayscale(0.7);
+  border-color: #2b2b2b;
+  background-image: linear-gradient(135deg, rgba(255, 90, 61, 0.12), rgba(0, 0, 0, 0.2));
   transform: none;
-  box-shadow: 8px 8px 0 0 rgba(0, 0, 0, 1);
+  box-shadow: 6px 6px 0 0 rgba(0, 0, 0, 1);
 }
 
 .contact-form__toast {

--- a/src/app/features/landing/contact/contact-form/contact-form.component.html
+++ b/src/app/features/landing/contact/contact-form/contact-form.component.html
@@ -44,6 +44,9 @@
           type="text"
           formControlName="nombre"
         />
+        @if (isInvalid('nombre')) {
+          <span class="contact-form__error">{{ getErrorMessage('nombre') }}</span>
+        }
       </div>
       <div class="contact-form__field">
         <label class="contact-form__label" for="correo">Correo</label>
@@ -56,6 +59,9 @@
           type="email"
           formControlName="correo"
         />
+        @if (isInvalid('correo')) {
+          <span class="contact-form__error">{{ getErrorMessage('correo') }}</span>
+        }
       </div>
       <div class="contact-form__field">
         <label class="contact-form__label" for="mensaje">Mensaje</label>
@@ -68,9 +74,12 @@
           rows="4"
           formControlName="mensaje"
         ></textarea>
+        @if (isInvalid('mensaje')) {
+          <span class="contact-form__error">{{ getErrorMessage('mensaje') }}</span>
+        }
       </div>
       <div class="contact-form__actions">
-        <button class="contact-form__submit" type="submit" [disabled]="isSending">
+        <button class="contact-form__submit" type="submit" [disabled]="isSending || form.invalid">
           {{ isSending ? 'ENVIANDO...' : 'ENVIAR AHORA!' }}
         </button>
       </div>

--- a/src/app/features/landing/contact/contact-form/contact-form.component.ts
+++ b/src/app/features/landing/contact/contact-form/contact-form.component.ts
@@ -42,6 +42,34 @@ export class ContactFormComponent {
     return control.invalid && (control.touched || control.dirty);
   }
 
+  protected getErrorMessage(controlName: keyof ContactFormGroup): string {
+    const control = this.form.controls[controlName];
+    const errors = control.errors;
+    if (!errors) {
+      return '';
+    }
+
+    if (errors['required']) {
+      if (controlName === 'nombre') {
+        return 'Nombre requerido.';
+      }
+      if (controlName === 'correo') {
+        return 'Correo requerido.';
+      }
+      return 'Mensaje requerido.';
+    }
+
+    if (controlName === 'correo' && errors['email']) {
+      return 'Correo inválido.';
+    }
+
+    if (controlName === 'mensaje' && errors['minlength']) {
+      return 'Mínimo 10 caracteres.';
+    }
+
+    return '';
+  }
+
   protected submit(): void {
     this.sendSuccess = false;
     this.sendError = false;


### PR DESCRIPTION
Added inline error messaging and helper mapping for form validation, and disabled the submit button when invalid or sending to improve UX feedback and prevent no-op submits.

Resolves #63