### PR TITLE
fix(ui): resolve double click requirement after closing gallery modal

### DIFF
--- a/src/app/features/project-detail/footage/project-detail-footage.component.ts
+++ b/src/app/features/project-detail/footage/project-detail-footage.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostListener, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, inject } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
 
 import { ProjectCard } from '../../../core/models/portfolio-content.model';
@@ -12,6 +12,8 @@ import { ProjectCard } from '../../../core/models/portfolio-content.model';
 })
 export class ProjectDetailFootageComponent {
   @Input({ required: true }) project!: ProjectCard;
+
+  private readonly cdr = inject(ChangeDetectorRef);
 
   protected selectedShot: GalleryShot | null = null;
   protected isClosing = false;
@@ -64,6 +66,7 @@ export class ProjectDetailFootageComponent {
       this.selectedShot = null;
       this.isClosing = false;
       this.closeTimeout = null;
+      this.cdr.markForCheck();
     }, 180);
   }
 


### PR DESCRIPTION
Injects ChangeDetectorRef into ProjectDetailFootageComponent and triggers markForCheck() when the polaroid enlarged view finishes closing. Given the component's OnPush change detection strategy, the asynchronous setTimeout callback was previously preventing Angular from removing the invisible modal from the DOM until the next user interaction, causing single clicks to be seemingly ignored.

Resolves #67